### PR TITLE
Updating installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ rosdep install --from-paths . --ignore-src --rosdistro kinetic
 * Install [**Gazebo**](http://gazebosim.org/), follow this [**link**](http://gazebosim.org/tutorials?tut=install_ubuntu&) for 
 instructions on how to install it on ubuntu. Make sure that the ros libraries of Gazebo are also installed:
 ```
-$ sudo apt-get install ros-indigo-gazeboX-*
+$ sudo apt-get install ros-kinetic-gazebo-ros-pkgs ros-kinetic-gazebo-ros-control
 ```
 * Finally compile your packages
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $  wstool up
 $ rosdep install --from-paths . --ignore-src --rosdistro kinetic 
 ```
 
-* Install [**Gazebo**](http://gazebosim.org/), follow this [**link**](http://gazebosim.org/tutorials?tut=install_ubuntu&) for 
+* Install [**Gazebo**](http://gazebosim.org/) (version 7 works with Kinetic), follow this [**link**](http://gazebosim.org/tutorials?tut=install_ubuntu&) for 
 instructions on how to install it on ubuntu. Make sure that the ros libraries of Gazebo are also installed:
 ```
 $ sudo apt-get install ros-kinetic-gazebo-ros-pkgs ros-kinetic-gazebo-ros-control

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ instructions on how to install it on ubuntu. Make sure that the ros libraries of
 ```
 $ sudo apt-get install ros-kinetic-gazebo-ros-pkgs ros-kinetic-gazebo-ros-control
 ```
-* Finally compile your packages
+* Finally compile your packages from catkin_ws directory
 ```
 $ catkin_make
 ```


### PR DESCRIPTION
- Updating command for installing Gazibo ROS packages in kinetic. The old command was for indigo.
- Adding a note that Gazibo7 should be installed on Kinetic.
- Adding a note where to run catkin_make command.
