### PR TITLE
Add cartesian force control

### DIFF
--- a/kuka_lwr/lwr_controllers/CMakeLists.txt
+++ b/kuka_lwr/lwr_controllers/CMakeLists.txt
@@ -89,6 +89,7 @@ set(INC_FILES ${INCLUDE_DIR}/controllers/gravity_compensation.h
               ${INCLUDE_DIR}/controllers/cartesian_position.h
               ${INCLUDE_DIR}/controllers/change_ctrl_mode.h
               ${INCLUDE_DIR}/controllers/passive_ds.h
+              ${INCLUDE_DIR}/controllers/cartesian_force.h
               )
 
 set(SRC_FILES ${SRC_DIR}/controllers/gravity_compensation.cpp
@@ -98,6 +99,7 @@ set(SRC_FILES ${SRC_DIR}/controllers/gravity_compensation.cpp
               ${SRC_DIR}/controllers/ff_fb_cartesian.cpp
               ${SRC_DIR}/controllers/change_ctrl_mode.cpp
               ${SRC_DIR}/controllers/passive_ds.cpp
+              ${SRC_DIR}/controllers/cartesian_force.cpp
 )
 
 set(INC_FILES_UTIL

--- a/kuka_lwr/lwr_controllers/include/controllers/cartesian_force.h
+++ b/kuka_lwr/lwr_controllers/include/controllers/cartesian_force.h
@@ -1,0 +1,36 @@
+#ifndef CARTESIAN_FORCE_H
+#define CARTESIAN_FORCE_H
+
+#include "base_controllers.h"
+#include "controllers/change_ctrl_mode.h"
+
+#include <ros/ros.h>
+#include <Eigen/Eigen>
+#include <kdl/jntarray.hpp>
+#include <geometry_msgs/Wrench.h>
+
+namespace controllers {
+    class Cartesian_force  : public Base_controllers {
+    public:
+        Cartesian_force(ros::NodeHandle& nh, controllers::Change_ctrl_mode& change_ctrl_mode);
+
+        void stop() override;
+
+        void update(KDL::JntArray& tau_cmd, const KDL::Jacobian&  J);
+
+    private:
+        /// ROS topic callback
+        void command_cart_force(const geometry_msgs::WrenchConstPtr& msg);
+
+        /// Ctrl mode
+        Change_ctrl_mode&   change_ctrl_mode;
+        bool                bFirst;
+
+        /// ROS topic
+        ros::Subscriber     sub_command_force_;
+
+        Eigen::VectorXd     F_ee_des_;         // desired end-effector force and torque
+    };
+}
+
+#endif

--- a/kuka_lwr/lwr_controllers/include/lwr_controllers/joint_controllers.h
+++ b/kuka_lwr/lwr_controllers/include/lwr_controllers/joint_controllers.h
@@ -43,6 +43,7 @@
 #include "controllers/cartesian_position.h"
 #include "controllers/change_ctrl_mode.h"
 #include "controllers/passive_ds.h"
+#include "controllers/cartesian_force.h"
 
 #include "utils/definitions.h"
 #include "utils/contact_safety.h"
@@ -98,6 +99,7 @@ namespace lwr_controllers
         boost::scoped_ptr<controllers::Joint_position>         joint_position_controller;
         boost::scoped_ptr<controllers::Gravity_compensation>   gravity_compensation_controller;
         boost::scoped_ptr<controllers::Passive_ds>             passive_ds_controller;
+        boost::scoped_ptr<controllers::Cartesian_force>        cartesian_force_controller;
 
 		ros::Subscriber sub_gains_;
 		ros::Subscriber sub_posture_;

--- a/kuka_lwr/lwr_controllers/include/utils/definitions.h
+++ b/kuka_lwr/lwr_controllers/include/utils/definitions.h
@@ -9,6 +9,7 @@ enum class CTRL_MODE{
     CART_VELOCITIY,         /// velocity
     CART_POSITION,          /// position
     CART_PASSIVE_DS,        /// passive ds (velocity cart)
+    CART_FORCE,             /// force and torque
     JOINT_POSITION,         /// standard joint position controller (for goto joint pose)
     GRAV_COMP,              /// sets the controller into gravity compensation
     FF_FB_CARTESIAN         /// feedforward + feedback trajectory for the end effector
@@ -29,6 +30,8 @@ inline std::string ctrl_mod2str(CTRL_MODE mode)
         return "CART_PASSIVE_DS";
     case CTRL_MODE::CART_POSITION:
         return "CART_POSITION";
+    case CTRL_MODE::CART_FORCE:
+        return "CART_FORCE";
     case CTRL_MODE::JOINT_POSITION:
         return "JOINT_POSITION";
     case CTRL_MODE::GRAV_COMP:

--- a/kuka_lwr/lwr_controllers/src/controllers/cartesian_force.cpp
+++ b/kuka_lwr/lwr_controllers/src/controllers/cartesian_force.cpp
@@ -1,0 +1,42 @@
+#include "controllers/cartesian_force.h"
+
+namespace controllers {
+    Cartesian_force::Cartesian_force(ros::NodeHandle& nh, controllers::Change_ctrl_mode& change_ctrl_mode) :
+        Base_controllers(lwr_controllers::CTRL_MODE::CART_FORCE),
+        change_ctrl_mode(change_ctrl_mode)
+    {
+        sub_command_force_ = nh.subscribe("command_wrench", 1, &Cartesian_force::command_cart_force, this, ros::TransportHints().reliable().tcpNoDelay());
+        F_ee_des_.resize(6);
+        F_ee_des_ << 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f;
+        bFirst = false;
+    }
+
+    void Cartesian_force::stop()
+    {
+        ROS_INFO_STREAM("stopping [CART_FORCE]");
+        F_ee_des_ << 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f;
+        bFirst = false;
+    }
+
+    void Cartesian_force::update(KDL::JntArray& tau_cmd, const KDL::Jacobian& J)
+    {
+        tau_cmd.data = J.data.transpose() * F_ee_des_;
+    }
+
+    void Cartesian_force::command_cart_force(const geometry_msgs::WrenchConstPtr& msg)
+    {
+        F_ee_des_(0) = msg->force.x;
+        F_ee_des_(1) = msg->force.y;
+        F_ee_des_(2) = msg->force.z;
+        F_ee_des_(3) = msg->torque.x;
+        F_ee_des_(4) = msg->torque.y;
+        F_ee_des_(5) = msg->torque.z;
+
+        if (!bFirst) {
+            change_ctrl_mode.switch_mode(lwr_controllers::CTRL_MODE::CART_FORCE);
+        }
+        bFirst = true;
+        ROS_INFO("CART_FORCE: Command received");
+    }
+
+} // namespace controllers

--- a/kuka_lwr/lwr_controllers/src/joint_controllers.cpp
+++ b/kuka_lwr/lwr_controllers/src/joint_controllers.cpp
@@ -97,6 +97,7 @@ bool JointControllers::init(hardware_interface::KUKAJointInterface *robot, ros::
     gravity_compensation_controller.reset(new controllers::Gravity_compensation(nh_,change_ctrl_mode));
     cartesian_position_controller.reset(new controllers::Cartesian_position(nh_,change_ctrl_mode));
     passive_ds_controller.reset(new controllers::Passive_ds(nh_,change_ctrl_mode));
+    cartesian_force_controller.reset(new controllers::Cartesian_force(nh_, change_ctrl_mode));
 
     change_ctrl_mode.add(ff_fb_controller.get());
     change_ctrl_mode.add(cartesian_velocity_controller.get());
@@ -104,6 +105,7 @@ bool JointControllers::init(hardware_interface::KUKAJointInterface *robot, ros::
     change_ctrl_mode.add(gravity_compensation_controller.get());
     change_ctrl_mode.add(cartesian_position_controller.get());
     change_ctrl_mode.add(passive_ds_controller.get());
+    change_ctrl_mode.add(cartesian_force_controller.get());
 
     ROS_INFO("JointControllers::init finished initialise [controllers]!");
 
@@ -209,6 +211,14 @@ void JointControllers::update(const ros::Time& time, const ros::Duration& period
             ROS_INFO_STREAM_THROTTLE(thrott_time,"ctrl_mode ===> CART_PASSIVE_DS");
             // passive_ds_controller->update(tau_cmd_,J_,x_dt_msr_.GetTwist(),x_msr_.M,x_msr_.p);
             passive_ds_controller->update(wrench,tau_cmd_,J_,joint_msr_,x_dt_msr_.GetTwist(),x_msr_.M,x_msr_.p);
+
+            robot_ctrl_mode = ROBOT_CTRL_MODE::TORQUE_IMP;
+            break;
+        }
+        case CTRL_MODE::CART_FORCE:
+        {
+            ROS_INFO_STREAM_THROTTLE(thrott_time,"ctrl_mode ===> CART_FORCE");
+            cartesian_force_controller->update(tau_cmd_, J_);
 
             robot_ctrl_mode = ROBOT_CTRL_MODE::TORQUE_IMP;
             break;


### PR DESCRIPTION
To enable the direct command of some end-effector wrench force and torque, a simple cartesian force "controller" is added. It converts a subscribed EE wrench (in base reference frame!) into joint torques, which the joint_controller then applies in the torque impedence robot control mode.

- Create new derived Base_controller class Cartesian_force
- Subscribe to topic "command_wrench" of type geometry_msg/Wrench to update property F_ee_des (desired end-effector wrench force)
- On update(&torque, Jacobian), calculate joint torque with Jacobian^T * F_ee_des
- Add new control mode CART_FORCE which calls the cartesian force controller and switches to TORQUE_IMP robot mode.


Tested in simulation with:
`roslaunch lwr_simple_example sim.launch`
`rostopic pub -1 /lwr/joint_controllers/command_wrench geometry_msgs/Wrench '{force: {x: 0, y: 0, z: 0}, torque: {x: 0, y: 0, z: 0}}'` (modify to see the effect).

What's the point of all this? I think it allows the controller for the specific application to be split from this lwr repo itself. Specifically, I want to experiment with different passive DS controllers to couple position and orientation. Since `passive_ds_controller` is already defined in another repo, I can make a standalone controller node to use / configure / extend it, and then just send the generated force / torque to the robot in this manner. I leave the task of converting to joint space to the lwr repo, so the external control node can be robot agnostic.