### PR TITLE
mention installation of ncurses library for successful catkin_make

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ $  wstool update
 ```
 $ rosdep update --include-eol- && rosdep install --from-paths -y . --ignore-src --rosdistro ${ROS_DISTRIB}
 ```
-
+* Additionlly, make sure the *ncurses* library is installed on your system
+```
+$ sudo apt-get install lib32ncurses5-dev
+```
 * Install [**Gazebo**](http://gazebosim.org/), follow this [**link**](http://gazebosim.org/tutorials?tut=install_ubuntu&) for 
 instructions on how to install it on ubuntu. Make sure that the ros libraries of Gazebo are also installed:
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ rosdep update --include-eol- && rosdep install --from-paths -y . --ignore-src 
 ```
 * Additionlly, make sure the *ncurses* library is installed on your system
 ```
-$ sudo apt-get install lib32ncurses5-dev
+$ sudo apt-get install libncurses5-dev
 ```
 * Install [**Gazebo**](http://gazebosim.org/), follow this [**link**](http://gazebosim.org/tutorials?tut=install_ubuntu&) for 
 instructions on how to install it on ubuntu. Make sure that the ros libraries of Gazebo are also installed:


### PR DESCRIPTION
just a small addition in the installation instructions. ncurses is not installed by default on ubuntu 18